### PR TITLE
Release/3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To run and test the library localy, simply:
   - [Props](#props)
     - [outputHeight](#outputHeight)
     - [outputWidth](#outputWidth)
-    - [background](#background)
-    - [foreground](#foreground)
+    - [backgrounds](#backgrounds)
+    - [foregrounds](#foregrounds)
     - [frame](#frame)
 - [Sticker](#sticker)
   - [Props](#props-1)
@@ -235,8 +235,8 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onDelete={(key) => {
-            setStickers((stickers) => deleteSticker(stickers, key))
+          onDelete={(id) => {
+            setStickers((stickers) => deleteSticker(stickers, id))
           }}
         />
       ))}
@@ -268,9 +268,9 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onReorder={(direction, extreme, key) => {
+          onReorder={(direction, extreme, id) => {
             setStickers((stickers) =>
-              reorderSticker({ key, direction, extreme, stickers })
+              reorderSticker({ id, direction, extreme, stickers })
             )
           }}
         />
@@ -301,9 +301,9 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onPosition={(value, key) => {
+          onPosition={(value, id) => {
             setStickers((stickers) =>
-              patchSticker({ stickers, prop: 'position', value, key })
+              patchSticker({ stickers, prop: 'position', value, id })
             )
           }}
         />
@@ -334,9 +334,9 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onScale={(value, key) => {
+          onScale={(value, id) => {
             setStickers((stickers) =>
-              patchSticker({ stickers, prop: 'scale', value, key })
+              patchSticker({ stickers, prop: 'scale', value, id })
             )
           }}
         />
@@ -367,9 +367,9 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onRotate={(value, key) => {
+          onRotate={(value, id) => {
             setStickers((stickers) =>
-              patchSticker({ stickers, prop: 'rotation', value, key })
+              patchSticker({ stickers, prop: 'rotation', value, id })
             )
           }}
         />
@@ -390,8 +390,8 @@ Returns a representation of the stickerbook in the chosen `format`.
 **options** | `Object`  
 **options.canvas** | `HTMLCanvasElement` | **optional** - A canvas element to draw to.  
 **options.backgrounds** | `Array` | **optional** - An array of valid [`background`](#backgrounds) objects.  
-**options. frame** | `Object` | **optional** - A valid [`frame`](#frame) object.  
-**options. foregrounds** | `Object` | **optional** - An array of valid [`foreground`](#foregrounds) objects.  
+**options.frame** | `Object` | **optional** - A valid [`frame`](#frame) object.  
+**options.foregrounds** | `Object` | **optional** - An array of valid [`foreground`](#foregrounds) objects.  
 **options.stickers** | `Array` | **optional** - An array of valid [`sticker`](#sticker) objects.  
 **options.outputWidth** | `Integer` default `500` - Output width.  
 **options.outputHeight** | `Integer` default `500` - Output height.  
@@ -434,7 +434,7 @@ Returns a reordered copy of the provided `stickers` array.
 `Function`
 
 **options** | `Object`  
-**options.key** | `String|Number` - The key of the sticker that will be reordered within the stickers array.  
+**options.id** | `String|Number` - The id of the sticker that will be reordered within the stickers array.  
 **options.direction** | `String` default `"up"` - The order in which to move the sticker.  
 **options.extreme** | `Boolean` default `false` - If it should be brought to the edges of the array.  
 **options.stickers** | `Array` default `[]` - An array of valid [`sticker`](#sticker) objects.
@@ -453,9 +453,9 @@ const App = () => {
       {stickers.map((sticker, index) => (
         <Sticker
           {...sticker}
-          onReorder={(direction, extreme, key) => {
+          onReorder={(direction, extreme, id) => {
             setStickers((stickers) =>
-              reorderSticker({ key, direction, extreme, stickers })
+              reorderSticker({ id, direction, extreme, stickers })
             )
           }}
         />
@@ -481,7 +481,7 @@ Returns a copy of the provided `stickers` array without the selected sticker.
 `Function`
 
 **stickers** | `Array` - An array of valid [`sticker`](#sticker) objects.  
-**key** | `String|Number` - The key of the sticker that will be deleted from the stickers array.
+**id** | `String|Number` - The id of the sticker that will be deleted from the stickers array.
 
 ### patchSticker
 
@@ -491,7 +491,7 @@ Returns a copy of the provided `stickers` array with the updated ("patched") sti
 
 **options** | `Object`  
 **options.stickers** | `Array` - An array of valid [`sticker`](#sticker)  
-**options.key** | `String|Number` - The key of the sticker that will be amended within the stickers array.
+**options.id** | `String|Number` - The id of the sticker that will be amended within the stickers array.
 **options.value** | **optional** - The new value.  
 **options.prop** | `String` - The prop to be updated. Can be one of the folllwing:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1-beta.2",
+      "version": "3.0.1-beta.3",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.3",
+  "version": "3.0.1-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1-beta.3",
+      "version": "3.0.1-beta.4",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1-beta.0",
+      "version": "3.0.1-beta.1",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.0",
+      "version": "3.0.1-beta.0",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.4",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1-beta.4",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.1.0",
+      "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.1",
+  "version": "3.0.1-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1-beta.1",
+      "version": "3.0.1-beta.2",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.1",
+  "version": "3.0.1-beta.2",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.4",
+  "version": "3.1.0",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.0",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.3",
+  "version": "3.0.1-beta.4",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.1-beta.1",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,8 +17,8 @@ import foregroundImage2 from './foreground-2.png'
 import stickerImage from './sticker.png'
 
 const CANVAS_SIZE = {
-  width: 1200,
-  height: 680,
+  width: 500,
+  height: 500,
 }
 
 const GIPHY_API_URL = new URL('https://api.giphy.com/v1/stickers/random')
@@ -30,9 +30,11 @@ GIPHY_API_URL.search = new URLSearchParams({
 const BACKGROUNDS = [
   {
     image: backgroundImage,
+    type: 'scene',
   },
   {
     image: backgroundImage2,
+    type: 'scene',
   },
 ]
 
@@ -54,15 +56,8 @@ export function App() {
     {
       id: 'my-id-1',
       image: stickerImage,
-      position: { x: 0.3, y: 0.7 },
       order: 0,
     },
-    // {
-    //   id: 'my-id-2',
-    //   position: { x: 0.3, y: 0.7 },
-    //   image: stickerImage,
-    //   order: 1,
-    // },
   ])
   const downloadRef = useRef()
   const [hidden, setHidden] = useState(false)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,8 +17,8 @@ import foregroundImage2 from './foreground-2.png'
 import stickerImage from './sticker.png'
 
 const CANVAS_SIZE = {
-  width: 500,
-  height: 500,
+  width: 1200,
+  height: 680,
 }
 
 const GIPHY_API_URL = new URL('https://api.giphy.com/v1/stickers/random')
@@ -56,12 +56,12 @@ export function App() {
       image: stickerImage,
       order: 0,
     },
-    {
-      id: 'my-id-2',
-      position: { x: 0.3, y: 0.7 },
-      image: stickerImage,
-      order: 1,
-    },
+    // {
+    //   id: 'my-id-2',
+    //   position: { x: 0.3, y: 0.7 },
+    //   image: stickerImage,
+    //   order: 1,
+    // },
   ])
   const downloadRef = useRef()
   const [hidden, setHidden] = useState(false)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -130,13 +130,12 @@ export function App() {
       <button onClick={onAddSticker}>Add random sticker from GIPHY</button>
       <button onClick={onClickDownload}>Download</button>
       <a ref={downloadRef} hidden="true" href="#" download="Stickerbook.png" />
-      <button
-        onClick={() => {
-          setHidden((state) => !state)
-        }}
-      >
+
+      {/* Toggle button for testing re-renders */}
+      <button onClick={() => setHidden((state) => !state)}>
         {hidden ? 'show' : 'hide'} stickerbook
       </button>
+
       {!hidden && (
         <div
           style={Object.entries(CANVAS_SIZE).reduce((acc, [key, val]) => {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -52,7 +52,7 @@ const FOREGROUNDS = [
 export function App() {
   const [stickers, setStickers] = useState([
     {
-      key: 'my-id-1',
+      id: 'my-id-1',
       image: stickerImage,
       order: 0,
     },
@@ -60,31 +60,31 @@ export function App() {
   const downloadRef = useRef()
 
   // Sticker hooks
-  const onReorderSticker = useCallback((direction, extreme, key) => {
+  const onReorderSticker = useCallback((direction, extreme, id) => {
     setStickers((stickers) =>
-      reorderSticker({ key, direction, extreme, stickers })
+      reorderSticker({ id, direction, extreme, stickers })
     )
   }, [])
 
-  const onDeleteSticker = useCallback((key) => {
-    setStickers((stickers) => deleteSticker(stickers, key))
+  const onDeleteSticker = useCallback((id) => {
+    setStickers((stickers) => deleteSticker(stickers, id))
   }, [])
 
-  const onPositionSticker = useCallback((value, key) => {
+  const onPositionSticker = useCallback((value, id) => {
     setStickers((stickers) =>
-      patchSticker({ stickers, prop: 'position', value, key })
+      patchSticker({ stickers, prop: 'position', value, id })
     )
   }, [])
 
-  const onScaleSticker = useCallback((value, key) => {
+  const onScaleSticker = useCallback((value, id) => {
     setStickers((stickers) =>
-      patchSticker({ stickers, prop: 'scale', value, key })
+      patchSticker({ stickers, prop: 'scale', value, id })
     )
   }, [])
 
-  const onRotateSticker = useCallback((value, key) => {
+  const onRotateSticker = useCallback((value, id) => {
     setStickers((stickers) =>
-      patchSticker({ stickers, prop: 'rotation', value, key })
+      patchSticker({ stickers, prop: 'rotation', value, id })
     )
   }, [])
 
@@ -141,7 +141,7 @@ export function App() {
         >
           {stickers.map((sticker) => (
             <Sticker
-              key={sticker.key}
+              key={sticker.id}
               onReorder={onReorderSticker}
               onDelete={onDeleteSticker}
               onPosition={onPositionSticker}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -58,6 +58,7 @@ export function App() {
     },
   ])
   const downloadRef = useRef()
+  const [hidden, setHidden] = useState(false)
 
   // Sticker hooks
   const onReorderSticker = useCallback((direction, extreme, id) => {
@@ -127,31 +128,40 @@ export function App() {
       <button onClick={onAddSticker}>Add random sticker from GIPHY</button>
       <button onClick={onClickDownload}>Download</button>
       <a ref={downloadRef} hidden="true" href="#" download="Stickerbook.png" />
-      <div
-        style={Object.entries(CANVAS_SIZE).reduce((acc, [key, val]) => {
-          return { ...acc, [`max-${key}`]: `${val}px` }
-        }, {})}
+      <button
+        onClick={() => {
+          setHidden((state) => !state)
+        }}
       >
-        <Stickerbook
-          outputWidth={CANVAS_SIZE.width}
-          outputHeight={CANVAS_SIZE.height}
-          backgrounds={BACKGROUNDS}
-          frame={FRAME}
-          foregrounds={FOREGROUNDS}
+        {hidden ? 'show' : 'hide'} stickerbook
+      </button>
+      {!hidden && (
+        <div
+          style={Object.entries(CANVAS_SIZE).reduce((acc, [key, val]) => {
+            return { ...acc, [`max-${key}`]: `${val}px` }
+          }, {})}
         >
-          {stickers.map((sticker) => (
-            <Sticker
-              key={sticker.id}
-              onReorder={onReorderSticker}
-              onDelete={onDeleteSticker}
-              onPosition={onPositionSticker}
-              onScale={onScaleSticker}
-              onRotate={onRotateSticker}
-              {...sticker}
-            />
-          ))}
-        </Stickerbook>
-      </div>
+          <Stickerbook
+            outputWidth={CANVAS_SIZE.width}
+            outputHeight={CANVAS_SIZE.height}
+            backgrounds={BACKGROUNDS}
+            frame={FRAME}
+            foregrounds={FOREGROUNDS}
+          >
+            {stickers.map((sticker) => (
+              <Sticker
+                key={sticker.id}
+                onReorder={onReorderSticker}
+                onDelete={onDeleteSticker}
+                onPosition={onPositionSticker}
+                onScale={onScaleSticker}
+                onRotate={onRotateSticker}
+                {...sticker}
+              />
+            ))}
+          </Stickerbook>
+        </div>
+      )}
       <a href="https://giphy.com/" target="_blank" rel="noreferrer">
         <img
           src="https://media.giphy.com/media/3o6gbbuLW76jkt8vIc/giphy.gif"

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -158,13 +158,14 @@ export function App() {
             {stickers.map((sticker) => (
               <Sticker
                 key={sticker.id}
+                initialPosition={sticker.position}
+                initialRotation={sticker.rotation}
+                initialScale={sticker.scale}
                 onReorder={onReorderSticker}
                 onDelete={onDeleteSticker}
                 onPosition={onPositionSticker}
                 onScale={onScaleSticker}
                 onRotate={onRotateSticker}
-                initialPosition={sticker.position}
-                initialScale={sticker.scale}
                 {...sticker}
               />
             ))}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -54,6 +54,7 @@ export function App() {
     {
       id: 'my-id-1',
       image: stickerImage,
+      position: { x: 0.3, y: 0.7 },
       order: 0,
     },
     // {
@@ -68,7 +69,6 @@ export function App() {
 
   // Sticker hooks
   const onReorderSticker = useCallback((direction, extreme, id) => {
-    console.log(stickers)
     setStickers((stickers) =>
       reorderSticker({ id, direction, extreme, stickers })
     )

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -56,12 +56,19 @@ export function App() {
       image: stickerImage,
       order: 0,
     },
+    {
+      id: 'my-id-2',
+      position: { x: 0.3, y: 0.7 },
+      image: stickerImage,
+      order: 1,
+    },
   ])
   const downloadRef = useRef()
   const [hidden, setHidden] = useState(false)
 
   // Sticker hooks
   const onReorderSticker = useCallback((direction, extreme, id) => {
+    console.log(stickers)
     setStickers((stickers) =>
       reorderSticker({ id, direction, extreme, stickers })
     )
@@ -156,6 +163,8 @@ export function App() {
                 onPosition={onPositionSticker}
                 onScale={onScaleSticker}
                 onRotate={onRotateSticker}
+                initialPosition={sticker.position}
+                initialScale={sticker.scale}
                 {...sticker}
               />
             ))}

--- a/src/lib/helpers/addSticker.js
+++ b/src/lib/helpers/addSticker.js
@@ -1,10 +1,10 @@
 export function addSticker(stickers = [], sticker) {
-  if (!sticker) throw Error("No `sticker` provided");
+  if (!sticker) throw Error('No `sticker` provided')
 
   // we add a unique key based on the time because otherwise the
   // sticker will loose its state when re-rendering it, even though
   // we save the state globally, this is a good failsafe
   return stickers.concat([
-    { ...sticker, order: stickers.length, key: Date.now() },
-  ]);
+    { ...sticker, order: stickers.length, id: Date.now() },
+  ])
 }

--- a/src/lib/helpers/deleteSticker.js
+++ b/src/lib/helpers/deleteSticker.js
@@ -1,18 +1,18 @@
-export function deleteSticker(stickers, key) {
+export function deleteSticker(stickers, id) {
   if (!stickers || !(stickers instanceof Array) || stickers.length <= 0)
     throw Error('`stickers` array is empty')
 
   const [filteredStickers, deletedSticker] = stickers.reduce(
     (acc, s) => {
-      if (s.key !== key) acc[0].push(s)
+      if (s.id !== id) acc[0].push(s)
       else acc[1] = s
 
       return acc
     },
     [[], null]
   )
-  if (!key || !deletedSticker)
-    throw Error('`key` needs to be a valid `sticker` key')
+  if (!id || !deletedSticker)
+    throw Error('`id` needs to be a valid `sticker` id')
 
   return filteredStickers.map((item) => {
     // fix the order

--- a/src/lib/helpers/patchSticker.js
+++ b/src/lib/helpers/patchSticker.js
@@ -1,11 +1,11 @@
-export function patchSticker({ stickers, prop, value, key }) {
+export function patchSticker({ stickers, prop, value, id }) {
   if (!stickers || !(stickers instanceof Array) || stickers.length <= 0)
     throw Error('`stickers` array is empty')
 
-  const patchedSticker = stickers.find((sticker) => sticker.key === key)
+  const patchedSticker = stickers.find((sticker) => sticker.id === id)
 
-  if (!key || !patchedSticker)
-    throw Error('`key` needs to be a valid `sticker` key')
+  if (!id || !patchedSticker)
+    throw Error('`id` needs to be a valid `sticker` id')
 
   const PROPS = ['position', 'scale', 'rotation']
 

--- a/src/lib/helpers/renderSticker.js
+++ b/src/lib/helpers/renderSticker.js
@@ -54,8 +54,6 @@ const initApplication = (size) => {
   c.height = size[1]
   dims = new Vec2(c.width, c.height)
 
-  document.body.appendChild(c)
-
   return c
 }
 

--- a/src/lib/helpers/renderSticker.js
+++ b/src/lib/helpers/renderSticker.js
@@ -50,8 +50,8 @@ const initApplication = (size) => {
 
     components.initialized = true
   }
-  c.height = size[0]
-  c.width = size[1]
+  c.width = size[0]
+  c.height = size[1]
   dims = new Vec2(c.width, c.height)
 
   return c

--- a/src/lib/helpers/renderSticker.js
+++ b/src/lib/helpers/renderSticker.js
@@ -54,6 +54,8 @@ const initApplication = (size) => {
   c.height = size[1]
   dims = new Vec2(c.width, c.height)
 
+  document.body.appendChild(c)
+
   return c
 }
 
@@ -73,7 +75,7 @@ const renderSticker = (sticker, canvasSize) => {
   // const position = sticker.position.subtractNew(new Vec2(0.5)).scale(c.width);
   const position = sticker.position.clone()
   position.y = 1 - position.y
-  position.scale(c.width).subtract(dims.scaleNew(0.5))
+  position.multiply(dims).subtract(dims.scaleNew(0.5))
   const scale = (sticker.scale * c.width) / Math.min(d.x, d.y) / 0.5
   let a = sticker.rotation
   let rotation = new Mat3(
@@ -100,8 +102,8 @@ const renderSticker = (sticker, canvasSize) => {
     1
   )
   const sizeTransformationMatrix = size
-    .multiply(rotation)
-    .multiplyNew(transform)
+    .multiplyNew(rotation)
+    .multiply(transform)
   // const sizeTransformationMatrix = rotation;
 
   window.sizeTransformationMatrix = sizeTransformationMatrix

--- a/src/lib/helpers/reorderSticker.js
+++ b/src/lib/helpers/reorderSticker.js
@@ -1,5 +1,5 @@
 export function reorderSticker({
-  key,
+  id,
   direction = 'up',
   extreme = false,
   stickers = [],
@@ -9,8 +9,8 @@ export function reorderSticker({
   if (!direction || !['up', 'down'].includes(direction))
     throw Error('`direction` needs to be either `up` or `down`')
 
-  const sticker = stickers.find((item) => item.key === key)
-  if (!sticker) throw Error('`key` needs to be a valid `sticker` key')
+  const sticker = stickers.find((item) => item.id === id)
+  if (!sticker) throw Error('`id` needs to be a valid `sticker` id')
 
   // First, we can't change the array itself otherwise
   // it will cause a re-render and the item will loose focus.
@@ -36,7 +36,7 @@ export function reorderSticker({
 
   return stickers.map((item) => {
     // if it's our item we update its order
-    if (item.key === key) item.order = newOrder
+    if (item.id === id) item.order = newOrder
     else if (direction === 'up') {
       // if we are going to the extreme edges, we gotta
       // move all stickers before/after the new order

--- a/src/lib/sticker.jsx
+++ b/src/lib/sticker.jsx
@@ -493,7 +493,7 @@ export default function Sticker({
   }
 
   // if the parent stickerbook changes size we need to respond
-  const currentPercentageShift = useRef()
+  const currentPercentageShift = useRef(parentDimensions.percentageShift)
   useEffect(() => {
     if (!imageDetails) return
 

--- a/src/lib/sticker.jsx
+++ b/src/lib/sticker.jsx
@@ -15,7 +15,7 @@ const STATES = {
 const ROTATION_BUTTON_OFFSET = 0.785
 
 export default function Sticker({
-  key,
+  id,
   image,
   alt = '',
   order = 0,
@@ -164,86 +164,83 @@ export default function Sticker({
 
   const onStickerKeyDown = function (e) {
     if (state === STATES.IDLE) {
-      const { shiftKey, key: eventKey } = e
+      const { shiftKey, key } = e
       const multiplier = shiftKey ? 10 : 1
 
-      if ((eventKey === 'Delete' || eventKey === 'Backspace') && onDelete)
-        onDelete(key)
+      if ((key === 'Delete' || key === 'Backspace') && onDelete) onDelete(id)
 
       // move left
-      if (eventKey === 'ArrowLeft') {
+      if (key === 'ArrowLeft') {
         e.preventDefault()
         e.stopPropagation()
         setPosition((cur) => new Vec2(cur.x - 1 * multiplier, cur.y))
       }
       // move right
-      else if (eventKey === 'ArrowRight') {
+      else if (key === 'ArrowRight') {
         e.preventDefault()
         e.stopPropagation()
         setPosition((cur) => new Vec2(cur.x + 1 * multiplier, cur.y))
       }
 
       // move up
-      if (eventKey === 'ArrowUp') {
+      if (key === 'ArrowUp') {
         e.preventDefault()
         e.stopPropagation()
         setPosition((cur) => new Vec2(cur.x, cur.y - 1 * multiplier))
       }
       // move down
-      else if (eventKey === 'ArrowDown') {
+      else if (key === 'ArrowDown') {
         e.preventDefault()
         e.stopPropagation()
         setPosition((cur) => new Vec2(cur.x, cur.y + 1 * multiplier))
       }
 
       // scale down
-      if (eventKey === '-' || eventKey === '_')
+      if (key === '-' || key === '_')
         setScale((cur) => Math.max(0.05, cur - 0.01 * multiplier))
       // scale up
-      else if (eventKey === '+' || eventKey === '=')
+      else if (key === '+' || key === '=')
         setScale((cur) => cur + 0.01 * multiplier)
 
       // rotate left
-      if (eventKey === '<' || eventKey === ',')
+      if (key === '<' || key === ',')
         setRotation((cur) => cur - 0.01 * multiplier)
       // rotate right
-      else if (eventKey === '>' || eventKey === '.')
+      else if (key === '>' || key === '.')
         setRotation((cur) => cur + 0.01 * multiplier)
 
       // Align top
-      if (eventKey === 'w')
-        setPosition((cur) => new Vec2(cur.x, cur.y - bounds.top))
+      if (key === 'w') setPosition((cur) => new Vec2(cur.x, cur.y - bounds.top))
       // align bottom
-      else if (eventKey === 's')
+      else if (key === 's')
         setPosition(
           (cur) =>
             new Vec2(cur.x, parentDimensions.height - (bounds.bottom - cur.y))
         )
 
       // Align left
-      if (eventKey === 'a')
+      if (key === 'a')
         setPosition((cur) => new Vec2(cur.x - bounds.left, cur.y))
       // align right
-      else if (eventKey === 'd')
+      else if (key === 'd')
         setPosition(
           (cur) =>
             new Vec2(parentDimensions.width - (bounds.right - cur.x), cur.y)
         )
 
       // center align vertically
-      if (eventKey === 'v')
+      if (key === 'v')
         setPosition((cur) => new Vec2(cur.x, parentDimensions.height * 0.5))
       // center align horizontally
-      else if (eventKey === 'c')
+      else if (key === 'c')
         setPosition((cur) => new Vec2(parentDimensions.width * 0.5, cur.y))
 
       if (onReorder) {
         // bring forwards
-        if (eventKey === '[' || eventKey === '{')
-          onReorder('up', multiplier > 1, key)
+        if (key === '[' || key === '{') onReorder('up', multiplier > 1, id)
         // bring backwards
-        else if (eventKey === ']' || eventKey === '}')
-          onReorder('down', multiplier > 1, key)
+        else if (key === ']' || key === '}')
+          onReorder('down', multiplier > 1, id)
       }
     }
   }
@@ -297,7 +294,7 @@ export default function Sticker({
   }
 
   const onDeleteClick = function () {
-    if (onDelete) onDelete(key)
+    if (onDelete) onDelete(id)
   }
 
   const onPinPointerDown = function () {
@@ -400,7 +397,7 @@ export default function Sticker({
     } else {
       // If, instead, this sticker has been clicked then focus it, set it to moving and add the pointer move event
       element.focus()
-      if (onReorder) onReorder('up', true, key)
+      if (onReorder) onReorder('up', true, id)
       setState(STATES.MOVE)
     }
   }
@@ -420,23 +417,23 @@ export default function Sticker({
         // Basically, this is a value that can be reverted
         // by multiplying it back to whatever size you need
         if (position)
-          onPosition(position.divideScalarNew(parentDimensions.width), key)
+          onPosition(position.divideScalarNew(parentDimensions.width), id)
       }, 100)
     }
-  }, [onPosition, position, parentDimensions.width, key])
+  }, [onPosition, position, parentDimensions.width, id])
 
   useEffect(() => {
     if (onRotate) {
       clearTimeout(onRotateTimer.current)
       onRotateTimer.current = setTimeout(() => {
-        onRotate(rotation, key)
+        onRotate(rotation, id)
       }, 500)
     }
 
     return () => {
       clearTimeout(onRotateTimer.current)
     }
-  }, [onRotate, rotation, key])
+  }, [onRotate, rotation, id])
 
   useEffect(() => {
     if (onScale) {
@@ -447,14 +444,14 @@ export default function Sticker({
         // model into the preact/funcional model
         // Basically, this is a value that can be reverted
         // by multiplying it back to whatever size you need
-        onScale(radius / parentDimensions.width, key)
+        onScale(radius / parentDimensions.width, id)
       }, 500)
     }
 
     return () => {
       clearTimeout(onScaleTimer.current)
     }
-  }, [onScale, radius, parentDimensions.width, key])
+  }, [onScale, radius, parentDimensions.width, id])
 
   // start it all after image loads
   const init = async function (e) {

--- a/src/lib/sticker.jsx
+++ b/src/lib/sticker.jsx
@@ -417,10 +417,21 @@ export default function Sticker({
         // Basically, this is a value that can be reverted
         // by multiplying it back to whatever size you need
         if (position)
-          onPosition(position.divideScalarNew(parentDimensions.width), id)
+          onPosition(
+            position.divideNew(
+              new Vec2(parentDimensions.width, parentDimensions.height)
+            ),
+            id
+          )
       }, 100)
     }
-  }, [onPosition, position, parentDimensions.width, id])
+  }, [
+    onPosition,
+    position,
+    parentDimensions.width,
+    parentDimensions.height,
+    id,
+  ])
 
   useEffect(() => {
     if (onRotate) {
@@ -474,7 +485,11 @@ export default function Sticker({
         ? new Vec2(initialPosition.x, initialPosition.y)
         : initialPosition
 
-      setPosition(position.scaleNew(parentDimensions.width))
+      setPosition(
+        position.multiplyNew(
+          new Vec2(parentDimensions.width, parentDimensions.height)
+        )
+      )
     } else
       setPosition(
         new Vec2(parentDimensions.width / 2, parentDimensions.height / 2)

--- a/src/lib/stickerbook.jsx
+++ b/src/lib/stickerbook.jsx
@@ -182,7 +182,7 @@ export default function Stickerbook({
           height: `${dimensions.height}px`,
         }}
       >
-        {backgrounds.length &&
+        {backgrounds.length > 0 &&
           backgrounds.map((bg, i) => {
             if (!bg.image) return null
 
@@ -219,7 +219,7 @@ export default function Stickerbook({
           {dimensions.rendered && children}
         </StickerbookContext.Provider>
 
-        {foregrounds.length &&
+        {foregrounds.length > 0 &&
           foregrounds.map((fg, i) => {
             if (!fg.image) return null
 


### PR DESCRIPTION
# Updates
- fix: rename sticker `key` prop to `id`. This was causing issues with a particular version of Preact.
- refactor: remove the need to pass `index` argument to Stickerbook helpers; rename all `key` arguments to `id` for consistency with the above fix.
- fix: ensure `renderSticker` function takes composition height into account. This allows for aspect ratios other than 1:1.
- feature: add support for multiple backgrounds.
- feature: add support for multiple foregrounds.
- update documentation
- update dev demo to allow for mounting and unmounting of stickerbook. Not a necessity, but helped to debug position/rotate/scale issues when they arose, so I'm leaving it in.