### PR TITLE
Feature/disable sticker rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ If no `initialScale` is provided `defaultScale` will be used.
 
 `number` default `0.3` | **optional**
 
+#### disableRotation
+
+Disables rotation of a given sticker.
+
+`Boolean` default `false` | **optional**
+
 #### onDelete
 
 A callback function to be called when the delete button is clicked.  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,7 +17,7 @@ import foregroundImage2 from './foreground-2.png'
 import stickerImage from './sticker.png'
 
 const CANVAS_SIZE = {
-  width: 1400,
+  width: 500,
   height: 500,
 }
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,7 +17,7 @@ import foregroundImage2 from './foreground-2.png'
 import stickerImage from './sticker.png'
 
 const CANVAS_SIZE = {
-  width: 500,
+  width: 1400,
   height: 500,
 }
 
@@ -160,6 +160,7 @@ export function App() {
                 onPosition={onPositionSticker}
                 onScale={onScaleSticker}
                 onRotate={onRotateSticker}
+                disableRotation={sticker.disableRotation}
                 {...sticker}
               />
             ))}

--- a/src/lib/sticker.jsx
+++ b/src/lib/sticker.jsx
@@ -24,6 +24,7 @@ export default function Sticker({
   initialRotation = null,
   initialPosition = null,
   defaultScale = 0.3,
+  disableRotation = false,
   // hooks
   onDelete,
   onReorder,
@@ -203,11 +204,15 @@ export default function Sticker({
         setScale((cur) => cur + 0.01 * multiplier)
 
       // rotate left
-      if (key === '<' || key === ',')
+      if (key === '<' || key === ',') {
+        if (disableRotation) return
         setRotation((cur) => cur - 0.01 * multiplier)
+      }
       // rotate right
-      else if (key === '>' || key === '.')
+      else if (key === '>' || key === '.') {
+        if (disableRotation) return
         setRotation((cur) => cur + 0.01 * multiplier)
+      }
 
       // Align top
       if (key === 'w') setPosition((cur) => new Vec2(cur.x, cur.y - bounds.top))
@@ -264,7 +269,8 @@ export default function Sticker({
       let initalradius = Math.min(imageDetails.x, imageDetails.y)
 
       // Update the rotation / scale of the sticker
-      setRotationOffset(mousePosition.angle - ROTATION_BUTTON_OFFSET)
+      if (!disableRotation)
+        setRotationOffset(mousePosition.angle - ROTATION_BUTTON_OFFSET)
       setScale(
         (mousePosition.length + (radius - radius * controlsScale)) /
           (initalradius * 0.5)


### PR DESCRIPTION
# Goal 
Allow for the disabling of Sticker rotation.

## Added
- `Sticker` now accepts a `disableRotation` prop, which defaults to `false`.

## Usage
```jsx
// (Assuming your sticker state is called `sticker` here)
<Sticker
  key={sticker.id}
  initialPosition={sticker.position}
  initialRotation={sticker.rotation}
  initialScale={sticker.scale}
  onReorder={onReorderSticker}
  onDelete={onDeleteSticker}
  onPosition={onPositionSticker}
  onScale={onScaleSticker}
  onRotate={onRotateSticker}
  disableRotation={sticker.disableRotation}
  {...sticker}
/>
```