### PR TITLE
fix: check for undefined props using `typeof`

### DIFF
--- a/src/lib/helpers/renderSticker.ts
+++ b/src/lib/helpers/renderSticker.ts
@@ -48,9 +48,17 @@ export function renderSticker(
   loadedImage: HTMLImageElement,
   canvasSize: Size
 ) {
-  if (!sticker.position) throw Error("Sticker position is not defined")
-  if (!sticker.scale) throw Error("Sticker scale is not defined")
-  if (!sticker.rotation) throw Error("Sticker rotation is not defined")
+  if (typeof sticker.position === "undefined") {
+    throw Error("Sticker position is not defined")
+  }
+
+  if (typeof sticker.scale === "undefined") {
+    throw Error("Sticker scale is not defined")
+  }
+
+  if (typeof sticker.rotation === "undefined") {
+    throw Error("Sticker rotation is not defined")
+  }
 
   initApplication(canvasSize)
 

--- a/src/lib/helpers/renderSticker.ts
+++ b/src/lib/helpers/renderSticker.ts
@@ -48,15 +48,21 @@ export function renderSticker(
   loadedImage: HTMLImageElement,
   canvasSize: Size
 ) {
-  if (typeof sticker.position === "undefined") {
+  if (
+    typeof sticker.position === "undefined" ||
+    typeof sticker.position.x === "undefined" ||
+    typeof sticker.position.y === "undefined" ||
+    isNaN(sticker.position.x) ||
+    isNaN(sticker.position.y)
+  ) {
     throw Error("Sticker position is not defined")
   }
 
-  if (typeof sticker.scale === "undefined") {
+  if (typeof sticker.scale === "undefined" || isNaN(sticker.scale)) {
     throw Error("Sticker scale is not defined")
   }
 
-  if (typeof sticker.rotation === "undefined") {
+  if (typeof sticker.rotation === "undefined" || isNaN(sticker.rotation)) {
     throw Error("Sticker rotation is not defined")
   }
 


### PR DESCRIPTION
An unfortunate side-effect of checking for undefined properties using a boolean conversion is that valid property values like `0` are converted to a falsey value, and throws an error despite having a valid property.

This check updates the `undefined` check by using `typeof`, which works with propert values equal to `0`.