### PR TITLE
Feature: Downgrade `wtc-simplegl` to `0.0.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "preact": "^10.13.1",
     "wtc-math": "^1.0.20",
-    "wtc-simplegl": "^0.0.8"
+    "wtc-simplegl": "^1.0.3"
   },
   "peerDependencies": {
     "preact": "^10.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "preact": "^10.13.1",
     "wtc-math": "^1.0.20",
-    "wtc-simplegl": "^1.0.3"
+    "wtc-simplegl": "^0.0.6"
   },
   "peerDependencies": {
     "preact": "^10.13.1"


### PR DESCRIPTION
This resolves a crash when running `exportStickerbook`.