### PR TITLE
Fixing issue with sticker rendition on android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
       },
       "engines": {
         "node": ">=v20.10.0"
+      },
+      "peerDependencies": {
+        "preact": "^10.13.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/src/lib/helpers/renderSticker.ts
+++ b/src/lib/helpers/renderSticker.ts
@@ -34,8 +34,9 @@ precision highp float;
 in vec2 v_uv;
 out vec4 color;
 uniform sampler2D s_main;
+uniform vec2 u_resolution;
 void main() {
-  vec2 uv = v_uv;
+  vec2 uv = gl_FragCoord.xy / u_resolution;
 
   color = texture(s_main, uv);
 }`


### PR DESCRIPTION
I think the issue was with the use of implicit UV coordinates on the the triangle used for rendition.

What we were doing is drawing a triangle with the following relationship to the screen.
│\
│█\

And I think Android is screwing the coordinates up. So I've changed it to make it generate the UVs as a part of screen rendition.