### PR TITLE
Fix: click event layering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/preact-stickerbook",
-      "version": "4.0.3",
+      "version": "4.0.5",
       "license": "ISC",
       "dependencies": {
         "preact": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/preact-stickerbook",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Easily create collage apps that are accessible by default.",
   "files": [
     "dist/*"

--- a/src/lib/sticker.tsx
+++ b/src/lib/sticker.tsx
@@ -400,8 +400,8 @@ export function Sticker({
       // This makes sure that when we click *through* the sticker we get the next one below instead of some random one in the stack.
       elements.sort((a, b) => {
         if (
-          a.classList.contains("Sticker__img") &&
-          b.classList.contains("Sticker__img")
+          a.classList.contains(styles.Sticker__img) &&
+          b.classList.contains(styles.Sticker__img)
         ) {
           if (!a.parentNode?.parentElement || !b.parentNode?.parentElement)
             return 0
@@ -419,7 +419,7 @@ export function Sticker({
       // Loop through the elements. If it belongs to a sticker then create a pointer event and "click" that sticker
       elements.forEach((element) => {
         if (
-          element.classList.contains("Sticker__img") &&
+          element.classList.contains(styles.Sticker__img) &&
           !element.classList.contains("Sticker--checking")
         ) {
           // create a specific "pointerdown" event


### PR DESCRIPTION
WTC time tracking: 
https://wethecollective.teamwork.com/app/tasks/22769488

## Overview
This PR fixes an issue where images were not being recognized as "stickers" when running the sorting/layering logic after a click event. This was due to an outdated CSS class that the code was checking for. Just replaces the hard-coded class string with the CSS module reference for it.

### Notes
Bumps the package to version `4.0.5`